### PR TITLE
feat: update queue connections to use 'redis-long' and add retry logic

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -226,7 +226,7 @@ return [
         ],
 
         'supervisor-3' => [
-            'connection' => 'redis',
+            'connection' => 'redis-long',
             'queue' => ['processing'],
             'balance' => 'auto',
             'autoScalingStrategy' => 'size',
@@ -243,7 +243,7 @@ return [
         ],
 
         'supervisor-4' => [
-            'connection' => 'redis',
+            'connection' => 'redis-long',
             'queue' => ['transcoding'],
             'balance' => 'auto',
             'autoScalingStrategy' => 'size',

--- a/config/queue.php
+++ b/config/queue.php
@@ -73,6 +73,15 @@ return [
             'after_commit' => false,
         ],
 
+        'redis-long' => [
+            'driver' => 'redis',
+            'connection' => env('REDIS_QUEUE_CONNECTION', 'default'),
+            'queue' => env('REDIS_QUEUE', 'default'),
+            'retry_after' => 14460,
+            'block_for' => null,
+            'after_commit' => false,
+        ],
+
         'deferred' => [
             'driver' => 'deferred',
         ],

--- a/src/Domain/Videos/Jobs/CreateVideo.php
+++ b/src/Domain/Videos/Jobs/CreateVideo.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Domain\Videos\Jobs;
 
-use DateTime;
+use Carbon\CarbonInterface;
 use Domain\Users\Models\User;
 use Domain\Videos\Actions\CreateVideoByImport;
 use Domain\Videos\DataObjects\VideoFile;
@@ -59,9 +59,9 @@ class CreateVideo implements ShouldBeUniqueUntilProcessing, ShouldQueueAfterComm
             ->onQueue('processing');
     }
 
-    public function retryUntil(): DateTime
+    public function retryUntil(): CarbonInterface
     {
-        return now()->plus(seconds: $this->timeout + 60);
+        return now()->addSeconds($this->timeout + 60);
     }
 
     public function handle(): void

--- a/src/Domain/Videos/Jobs/CreateVideo.php
+++ b/src/Domain/Videos/Jobs/CreateVideo.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Domain\Videos\Jobs;
 
+use DateTime;
 use Domain\Users\Models\User;
 use Domain\Videos\Actions\CreateVideoByImport;
 use Domain\Videos\DataObjects\VideoFile;
@@ -23,11 +24,6 @@ class CreateVideo implements ShouldBeUniqueUntilProcessing, ShouldQueueAfterComm
     use InteractsWithQueue;
     use Queueable;
     use SerializesModels;
-
-    /**
-     * @var int
-     */
-    public $tries = 1;
 
     /**
      * @var int
@@ -58,7 +54,14 @@ class CreateVideo implements ShouldBeUniqueUntilProcessing, ShouldQueueAfterComm
         public User $user,
         public VideoFile $file,
     ) {
-        $this->onQueue('processing');
+        $this
+            ->onConnection('redis-long')
+            ->onQueue('processing');
+    }
+
+    public function retryUntil(): DateTime
+    {
+        return now()->plus(seconds: $this->timeout + 60);
     }
 
     public function handle(): void
@@ -72,7 +75,7 @@ class CreateVideo implements ShouldBeUniqueUntilProcessing, ShouldQueueAfterComm
     public function middleware(): array
     {
         return [
-            (new WithoutOverlapping($this->uniqueId()))->dontRelease(),
+            (new WithoutOverlapping($this->uniqueId()))->expireAfter($this->timeout)->releaseAfter(60),
         ];
     }
 

--- a/src/Domain/Videos/Jobs/ImportVideo.php
+++ b/src/Domain/Videos/Jobs/ImportVideo.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Domain\Videos\Jobs;
 
+use DateTime;
 use Domain\Videos\Actions\ImportVideoFile;
 use Domain\Videos\DataObjects\VideoFile;
 use Domain\Videos\Models\Video;
@@ -23,11 +24,6 @@ class ImportVideo implements ShouldBeUniqueUntilProcessing, ShouldQueueAfterComm
     use InteractsWithQueue;
     use Queueable;
     use SerializesModels;
-
-    /**
-     * @var int
-     */
-    public $tries = 1;
 
     /**
      * @var int
@@ -58,7 +54,14 @@ class ImportVideo implements ShouldBeUniqueUntilProcessing, ShouldQueueAfterComm
         public Video $video,
         public VideoFile $file,
     ) {
-        $this->onQueue('processing');
+        $this
+            ->onConnection('redis-long')
+            ->onQueue('processing');
+    }
+
+    public function retryUntil(): DateTime
+    {
+        return now()->plus(seconds: $this->timeout + 60);
     }
 
     public function handle(): void
@@ -72,7 +75,7 @@ class ImportVideo implements ShouldBeUniqueUntilProcessing, ShouldQueueAfterComm
     public function middleware(): array
     {
         return [
-            (new WithoutOverlapping($this->uniqueId()))->dontRelease(),
+            (new WithoutOverlapping($this->uniqueId()))->expireAfter($this->timeout)->releaseAfter(60),
         ];
     }
 

--- a/src/Domain/Videos/Jobs/ImportVideo.php
+++ b/src/Domain/Videos/Jobs/ImportVideo.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Domain\Videos\Jobs;
 
-use DateTime;
+use Carbon\CarbonInterface;
 use Domain\Videos\Actions\ImportVideoFile;
 use Domain\Videos\DataObjects\VideoFile;
 use Domain\Videos\Models\Video;
@@ -59,9 +59,9 @@ class ImportVideo implements ShouldBeUniqueUntilProcessing, ShouldQueueAfterComm
             ->onQueue('processing');
     }
 
-    public function retryUntil(): DateTime
+    public function retryUntil(): CarbonInterface
     {
-        return now()->plus(seconds: $this->timeout + 60);
+        return now()->addSeconds($this->timeout + 60);
     }
 
     public function handle(): void

--- a/src/Domain/Videos/Jobs/PlaylistVideo.php
+++ b/src/Domain/Videos/Jobs/PlaylistVideo.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Domain\Videos\Jobs;
 
+use DateTime;
 use Domain\Playlists\Enums\PlaylistType;
 use Domain\Playlists\Exceptions\PlaylistTypeException;
 use Domain\Playlists\Models\Playlist;
@@ -28,11 +29,6 @@ class PlaylistVideo implements ShouldBeUniqueUntilProcessing, ShouldQueueAfterCo
     use InteractsWithQueue;
     use Queueable;
     use SerializesModels;
-
-    /**
-     * @var int
-     */
-    public $tries = 1;
 
     /**
      * @var int
@@ -63,7 +59,9 @@ class PlaylistVideo implements ShouldBeUniqueUntilProcessing, ShouldQueueAfterCo
         public Video $video,
         public ?PlaylistType $type = null,
     ) {
-        $this->onQueue('transcoding');
+        $this
+            ->onConnection('redis-long')
+            ->onQueue('transcoding');
     }
 
     public function handle(): void
@@ -85,8 +83,13 @@ class PlaylistVideo implements ShouldBeUniqueUntilProcessing, ShouldQueueAfterCo
     public function middleware(): array
     {
         return [
-            (new WithoutOverlapping($this->uniqueId()))->dontRelease(),
+            (new WithoutOverlapping($this->uniqueId()))->expireAfter($this->timeout)->releaseAfter(60),
         ];
+    }
+
+    public function retryUntil(): DateTime
+    {
+        return now()->plus(seconds: $this->timeout + 60);
     }
 
     public function uniqueId(): string

--- a/src/Domain/Videos/Jobs/PlaylistVideo.php
+++ b/src/Domain/Videos/Jobs/PlaylistVideo.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Domain\Videos\Jobs;
 
-use DateTime;
+use Carbon\CarbonInterface;
 use Domain\Playlists\Enums\PlaylistType;
 use Domain\Playlists\Exceptions\PlaylistTypeException;
 use Domain\Playlists\Models\Playlist;
@@ -87,9 +87,9 @@ class PlaylistVideo implements ShouldBeUniqueUntilProcessing, ShouldQueueAfterCo
         ];
     }
 
-    public function retryUntil(): DateTime
+    public function retryUntil(): CarbonInterface
     {
-        return now()->plus(seconds: $this->timeout + 60);
+        return now()->addSeconds($this->timeout + 60);
     }
 
     public function uniqueId(): string

--- a/src/Domain/Videos/Jobs/TranscodeVideo.php
+++ b/src/Domain/Videos/Jobs/TranscodeVideo.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Domain\Videos\Jobs;
 
-use DateTime;
+use Carbon\CarbonInterface;
 use Domain\Videos\Actions\CreateNewVideoTranscode;
 use Domain\Videos\Models\Video;
 use Illuminate\Bus\Batchable;
@@ -62,9 +62,9 @@ class TranscodeVideo implements ShouldBeUniqueUntilProcessing, ShouldQueueAfterC
         app(CreateNewVideoTranscode::class)->handle($this->video);
     }
 
-    public function retryUntil(): DateTime
+    public function retryUntil(): CarbonInterface
     {
-        return now()->plus(seconds: $this->timeout + 60);
+        return now()->addSeconds($this->timeout + 60);
     }
 
     /**

--- a/src/Domain/Videos/Jobs/TranscodeVideo.php
+++ b/src/Domain/Videos/Jobs/TranscodeVideo.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Domain\Videos\Jobs;
 
+use DateTime;
 use Domain\Videos\Actions\CreateNewVideoTranscode;
 use Domain\Videos\Models\Video;
 use Illuminate\Bus\Batchable;
@@ -22,11 +23,6 @@ class TranscodeVideo implements ShouldBeUniqueUntilProcessing, ShouldQueueAfterC
     use InteractsWithQueue;
     use Queueable;
     use SerializesModels;
-
-    /**
-     * @var int
-     */
-    public $tries = 1;
 
     /**
      * @var int
@@ -56,12 +52,19 @@ class TranscodeVideo implements ShouldBeUniqueUntilProcessing, ShouldQueueAfterC
     public function __construct(
         public Video $video,
     ) {
-        $this->onQueue('transcoding');
+        $this
+            ->onConnection('redis-long')
+            ->onQueue('transcoding');
     }
 
     public function handle(): void
     {
         app(CreateNewVideoTranscode::class)->handle($this->video);
+    }
+
+    public function retryUntil(): DateTime
+    {
+        return now()->plus(seconds: $this->timeout + 60);
     }
 
     /**
@@ -70,7 +73,7 @@ class TranscodeVideo implements ShouldBeUniqueUntilProcessing, ShouldQueueAfterC
     public function middleware(): array
     {
         return [
-            (new WithoutOverlapping($this->uniqueId()))->dontRelease(),
+            (new WithoutOverlapping($this->uniqueId()))->expireAfter($this->timeout)->releaseAfter(60),
         ];
     }
 


### PR DESCRIPTION
This pull request updates the job queueing configuration and logic for video-related jobs to improve reliability and control over long-running tasks. The main changes involve introducing a new `redis-long` queue connection, updating supervisor configurations, and enhancing job retry and locking behavior.

**Queue Connection and Supervisor Configuration:**

* Added a new `redis-long` queue connection in `config/queue.php` with a longer `retry_after` value, intended for long-running jobs.
* Updated `supervisor-3` and `supervisor-4` in `config/horizon.php` to use the new `redis-long` connection for the `processing` and `transcoding` queues. [[1]](diffhunk://#diff-82a335c333ea3ccae729d98930bab170c4317d6539a64b8a9ec1022a989c0eb0L229-R229) [[2]](diffhunk://#diff-82a335c333ea3ccae729d98930bab170c4317d6539a64b8a9ec1022a989c0eb0L246-R246)

**Job Class Improvements:**

* Updated constructors in `CreateVideo`, `ImportVideo`, `PlaylistVideo`, and `TranscodeVideo` jobs to use the `redis-long` connection and their respective queues. [[1]](diffhunk://#diff-33de4191eec455bcfa011423cc60d90ed4b9393311cabfa52b95d11a1a335cb2L61-R64) [[2]](diffhunk://#diff-b9a45df0eb7cba156b9be2f28523f7df5220ce0eed0b7d6e3f8a9eee62aa8dc6L61-R64) [[3]](diffhunk://#diff-256caae9add9e7a2b7fac12cf28c21528ffcaa443dfac1f1e3335ee79e80e01dL66-R64) [[4]](diffhunk://#diff-6ade491c3540d5d77f0e3ed19f2517c1b1302aa37024d590bdbcbf8f34da86b1L59-R76)
* Added a `retryUntil` method to each job, ensuring jobs will be retried until a time based on their timeout plus 60 seconds. [[1]](diffhunk://#diff-33de4191eec455bcfa011423cc60d90ed4b9393311cabfa52b95d11a1a335cb2L61-R64) [[2]](diffhunk://#diff-b9a45df0eb7cba156b9be2f28523f7df5220ce0eed0b7d6e3f8a9eee62aa8dc6L61-R64) [[3]](diffhunk://#diff-256caae9add9e7a2b7fac12cf28c21528ffcaa443dfac1f1e3335ee79e80e01dL88-R94) [[4]](diffhunk://#diff-6ade491c3540d5d77f0e3ed19f2517c1b1302aa37024d590bdbcbf8f34da86b1L59-R76)
* Improved job locking by configuring the `WithoutOverlapping` middleware to expire after the job’s timeout and to release after 60 seconds, instead of not releasing. [[1]](diffhunk://#diff-33de4191eec455bcfa011423cc60d90ed4b9393311cabfa52b95d11a1a335cb2L75-R78) [[2]](diffhunk://#diff-b9a45df0eb7cba156b9be2f28523f7df5220ce0eed0b7d6e3f8a9eee62aa8dc6L75-R78) [[3]](diffhunk://#diff-256caae9add9e7a2b7fac12cf28c21528ffcaa443dfac1f1e3335ee79e80e01dL88-R94) [[4]](diffhunk://#diff-6ade491c3540d5d77f0e3ed19f2517c1b1302aa37024d590bdbcbf8f34da86b1L59-R76)

**Code Cleanup:**

* Removed the unused `$tries` property from all affected job classes. [[1]](diffhunk://#diff-33de4191eec455bcfa011423cc60d90ed4b9393311cabfa52b95d11a1a335cb2L27-L31) [[2]](diffhunk://#diff-b9a45df0eb7cba156b9be2f28523f7df5220ce0eed0b7d6e3f8a9eee62aa8dc6L27-L31) [[3]](diffhunk://#diff-256caae9add9e7a2b7fac12cf28c21528ffcaa443dfac1f1e3335ee79e80e01dL32-L36) [[4]](diffhunk://#diff-6ade491c3540d5d77f0e3ed19f2517c1b1302aa37024d590bdbcbf8f34da86b1L26-L30)