### PR TITLE
Update segment duration settings and remove unused configurations

### DIFF
--- a/config/laravel-shaka.php
+++ b/config/laravel-shaka.php
@@ -30,7 +30,7 @@ return [
     |
     */
 
-    'segment_duration' => (int) env('PACKAGER_SEGMENT_DURATION', 6),
+    'segment_duration' => (int) env('PACKAGER_SEGMENT_DURATION', 4),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/playlists.php
+++ b/config/playlists.php
@@ -52,44 +52,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Buffer Time
-    |--------------------------------------------------------------------------
-    |
-    | This value determines the minimum buffer time for the playlist in seconds.
-    | A common value is 2 seconds. Setting to 0 will use the default value.
-    |
-    */
-
-    'buffer_time' => (int) env('PLAYLIST_BUFFER_TIME', 2),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Segment Duration
-    |--------------------------------------------------------------------------
-    |
-    | This value determines the target duration of each media segment in seconds.
-    | Common values are 6, 10, or 12 seconds. Shorter durations can reduce latency but may
-    | increase overhead. Longer durations can improve efficiency but may increase latency.
-    |
-    */
-
-    'segment_duration' => (int) env('PLAYLIST_SEGMENT_DURATION', 6),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Fragment Duration
-    |--------------------------------------------------------------------------
-    |
-    | This value determines the target duration of each fragment in seconds.
-    | Fragments are used for fMP4 segments and can help with faster start times.
-    | Common values are 2 or 4 seconds. Setting to 0 will use the default value.
-    |
-    */
-
-    'fragment_duration' => (int) env('PLAYLIST_FRAGMENT_DURATION', 2),
-
-    /*
-    |--------------------------------------------------------------------------
     | Manifest Cache Lifetime
     |--------------------------------------------------------------------------
     |

--- a/config/streamer.php
+++ b/config/streamer.php
@@ -121,7 +121,7 @@ return [
     |
     */
 
-    'segment_duration' => (int) env('STREAMER_SEGMENT_DURATION', 6),
+    'segment_duration' => (int) env('STREAMER_SEGMENT_DURATION', 4),
 
     /*
     |--------------------------------------------------------------------------

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,11 +119,13 @@ VIDEO_COMPLETION_THRESHOLD=0.95
 ### Shaka Packager
 
 ```env
-# Segment duration for DASH/HLS segments (in seconds)
-PACKAGER_SEGMENT_DURATION=10
+# Segment duration for DASH/HLS segments (in seconds). Lower values reduce
+# seek latency (a seek waits for the segment covering the target time to
+# download) at the cost of more HTTP requests.
+PACKAGER_SEGMENT_DURATION=4
 
-# Number of concurrent write workers for s3. Default: 10
-PACKAGER_CONCURRENCY_WORKERS=32
+# Number of concurrent write workers for s3. Default: 30
+PACKAGER_CONCURRENCY_WORKERS=40
 ```
 
 ### Shaka Streamer
@@ -135,15 +137,16 @@ STREAMER_AUDIO_CODECS=aac,opus
 # Default video codecs (comma-separated)
 STREAMER_VIDEO_CODECS=hw:h264,hw:vp9
 
-# Default resolutions to generate (comma-separated)
-STREAMER_RESOLUTIONS=1080p,720p,480p
+# Segment duration for streaming (in seconds). Same seek-latency trade-off
+# as PACKAGER_SEGMENT_DURATION above.
+STREAMER_SEGMENT_DURATION=4
 
-# Segment duration for streaming (in seconds)
-STREAMER_SEGMENT_DURATION=10
-
-# Number of concurrent write workers for s3. Default: 10
-STREAMER_CONCURRENCY_WORKERS=32
+# Number of concurrent write workers for s3. Default: 30
+STREAMER_CONCURRENCY_WORKERS=40
 ```
+
+> [!NOTE]
+> Streamer resolutions aren't set via `.env` — they're detected automatically per video from the source stream's height (see `Foxws\Streamer\Support\VideoResolution`).
 
 ### AV1 Encoding (ab-av1)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -43,7 +43,10 @@ lpod install development/pgsql.quadlets --replace
 # ...and so on for every service (see podman.md)
 ```
 
-Set `APP_ENV=local`/`APP_DEBUG=true` (and any other local overrides) before storing them with `lpod stry secrets`.
+> [!TIP]
+> Set `PODMAN_DEFAULT_PRESETS` in `.env` (comma-separated, e.g. `PODMAN_DEFAULT_PRESETS=development,s3,devcontainer,proxy`) to skip passing `--preset` on every `podman:setup` run.
+
+Set `APP_ENV=local`/`APP_DEBUG=true`/`PWA_ENABLED=false` (and any other local overrides) before storing them with `lpod stry secrets`.
 
 Once the containers are up, install dependencies and seed data:
 
@@ -98,6 +101,7 @@ lpod stry bin larastan
 - **Container won't start** — `journalctl --user -u stry -f`; check for a missing/invalid `stry-env` secret or a port conflict (8000, 5173, 6001).
 - **Permission issues** — `chown -R 1000:1000 ~/projects/stry/storage` (match your `PODMAN_QUADLET_UID`/`GID` if you changed them).
 - **Assets not compiling** — `rm -rf bootstrap/ssr && lpod stry npm run build`.
+- **Tests fail with `could not translate host name "systemd-stry-pgsql"`** — you're running `php artisan test` directly on the host instead of inside the container network. Run `lpod stry up` first, then use `lpod stry artisan test`.
 
 ## Next steps
 

--- a/resources/js/composables/shaka.ts
+++ b/resources/js/composables/shaka.ts
@@ -85,7 +85,7 @@ export function useShaka(
           },
         },
         manifest: {
-          dash: { ignoreMinBufferTime: true, xlinkFailGracefully: true },
+          dash: { xlinkFailGracefully: true },
           hls: { ignoreImageStreamFailures: true, ignoreTextStreamFailures: true },
           retryParameters: {
             baseDelay: 100,

--- a/src/Domain/Playlists/DataObjects/PlaylistSettings.php
+++ b/src/Domain/Playlists/DataObjects/PlaylistSettings.php
@@ -9,17 +9,9 @@ use Spatie\LaravelData\Dto;
 
 class PlaylistSettings extends Dto
 {
-    public string $disk;
-
     public string $language;
 
     public string $textLanguage;
-
-    public int $bufferTime;
-
-    public int $segmentDuration;
-
-    public int $fragmentDuration;
 
     public bool $encryption;
 
@@ -33,12 +25,8 @@ class PlaylistSettings extends Dto
 
     public function __construct()
     {
-        $this->disk = Playlist::getDestinationDisk();
         $this->language = Playlist::getLanguage();
         $this->textLanguage = Playlist::getTextLanguage();
-        $this->bufferTime = Playlist::getBufferTime();
-        $this->segmentDuration = Playlist::getSegmentDuration();
-        $this->fragmentDuration = Playlist::getFragmentDuration();
         $this->encryption = Playlist::shouldUseEncryption();
         $this->keyRotation = Playlist::shouldUseKeyRotation();
         $this->encryptionMethod = Playlist::getEncryptionMethod();

--- a/src/Domain/Playlists/Models/Playlist.php
+++ b/src/Domain/Playlists/Models/Playlist.php
@@ -284,21 +284,6 @@ class Playlist extends Model
         return Config::string('playlists.text_language', 'en');
     }
 
-    public static function getBufferTime(): int
-    {
-        return Config::integer('playlists.buffer_time', 2);
-    }
-
-    public static function getSegmentDuration(): int
-    {
-        return Config::integer('playlists.segment_duration', 6);
-    }
-
-    public static function getFragmentDuration(): int
-    {
-        return Config::integer('playlists.fragment_duration', 2);
-    }
-
     public static function getManifestUrlLifetime(): int
     {
         return Config::integer('playlists.manifest_url_lifetime', 3600);

--- a/src/Domain/Videos/Actions/CreateNewVideoPlaylist.php
+++ b/src/Domain/Videos/Actions/CreateNewVideoPlaylist.php
@@ -87,16 +87,15 @@ class CreateNewVideoPlaylist
                 'type' => $type,
             ]);
 
-            // Configure the packager with common settings
+            // Configure the packager with common settings. Segment/fragment/buffer
+            // duration are left unset here so they fall back to the packager's own
+            // configured defaults (config/laravel-shaka.php).
             $packager
                 ->withMpdOutput($playlist->file_name)
                 ->withAllowCodecSwitching()
                 ->withAllowApproximateSegmentTimeline()
                 ->withDefaultLanguage($settings->language)
-                ->withDefaultTextLanguage($settings->textLanguage)
-                ->withMinBufferTime($settings->bufferTime)
-                ->withSegmentDuration($settings->segmentDuration)
-                ->withFragmentDuration($settings->fragmentDuration);
+                ->withDefaultTextLanguage($settings->textLanguage);
 
             // Export the playlist to the configured disk and path
             try {


### PR DESCRIPTION
This pull request refactors how playlist segment, fragment, and buffer durations are configured and used throughout the codebase. It removes these parameters from the playlist-level configuration and data objects, centralizing their control in the packager's own configuration (`config/laravel-shaka.php`). This makes the system less error-prone and easier to maintain by ensuring consistent defaults and reducing redundant configuration.

**Configuration simplification and centralization:**

* Removed `segment_duration`, `fragment_duration`, and `buffer_time` settings from `config/playlists.php` and their corresponding methods from the `Playlist` model, so these values are no longer set per-playlist but instead use the packager's defaults. [[1]](diffhunk://#diff-078b3ce83f2d18b901067a3f84b1f07d957443d9214322d43a52cae7727fb741L53-L90) [[2]](diffhunk://#diff-ff34da4adbd7201571f8fbe8f5411270c12fd4c010340793655cbd1f706a0688L287-L301)
* Updated the packager configuration defaults: reduced `segment_duration` from 6 to 4 seconds in both `config/laravel-shaka.php` and `config/streamer.php` for lower latency. [[1]](diffhunk://#diff-00efd40c2a11f11b429f34c4b0aa9a1571c52ba8ad32cce5d257de2ca0df9c07L33-R33) [[2]](diffhunk://#diff-08ee9e6b2f348884f1564931b88cee6bce6f7126a92379a51ca28cf05ac64c0fL124-R124)

**Code and data structure cleanup:**

* Removed `bufferTime`, `segmentDuration`, and `fragmentDuration` properties from `PlaylistSettings` and their initialization, reflecting that these are no longer needed at the playlist level. [[1]](diffhunk://#diff-9875eeb33585eda64f307581c0796578649eb9e74ee337b141f682f9b6beac4aL12-L23) [[2]](diffhunk://#diff-9875eeb33585eda64f307581c0796578649eb9e74ee337b141f682f9b6beac4aL36-L41)
* Updated playlist creation logic to stop setting segment, fragment, and buffer durations on the packager, allowing it to use its own configured defaults.

**Other changes:**

* Simplified Shaka player options by removing the `ignoreMinBufferTime` flag from the DASH manifest configuration.