### PR TITLE
feat: enhance playlist manifest handling with new refresh logic

### DIFF
--- a/config/playlists.php
+++ b/config/playlists.php
@@ -73,7 +73,7 @@ return [
     |
     */
 
-    'manifest_url_lifetime' => (int) env('PLAYLIST_MANIFEST_URL_LIFETIME', 7200),
+    'manifest_url_lifetime' => (int) env('PLAYLIST_MANIFEST_URL_LIFETIME', 14400),
 
     /*
     |--------------------------------------------------------------------------
@@ -100,7 +100,7 @@ return [
     |
     */
 
-    'media_url_lifetime' => (int) env('PLAYLIST_MEDIA_URL_LIFETIME', 7200),
+    'media_url_lifetime' => (int) env('PLAYLIST_MEDIA_URL_LIFETIME', 14400),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/playlists.php
+++ b/config/playlists.php
@@ -73,7 +73,21 @@ return [
     |
     */
 
-    'manifest_url_lifetime' => (int) env('PLAYLIST_MANIFEST_URL_LIFETIME', 3600),
+    'manifest_url_lifetime' => (int) env('PLAYLIST_MANIFEST_URL_LIFETIME', 7200),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Manifest Refresh Before
+    |--------------------------------------------------------------------------
+    |
+    | While a video is actively being watched, the video session heartbeat
+    | re-signs and broadcasts a fresh manifest URL this many seconds before
+    | the current one expires, so long-running playback never hits an
+    | expired signed URL.
+    |
+    */
+
+    'manifest_refresh_before' => (int) env('PLAYLIST_MANIFEST_REFRESH_BEFORE', 300),
 
     /*
     |--------------------------------------------------------------------------

--- a/database/factories/PlaylistFactory.php
+++ b/database/factories/PlaylistFactory.php
@@ -20,7 +20,7 @@ class PlaylistFactory extends Factory
     {
         return [
             'user_id' => User::factory(),
-            'playlistable_type' => Video::class,
+            'playlistable_type' => (new Video)->getMorphClass(),
             'playlistable_id' => Video::factory(),
             'disk' => 'segments',
             'file_name' => fake()->uuid().'.mpd',

--- a/resources/js/__tests__/composables/playlist.test.ts
+++ b/resources/js/__tests__/composables/playlist.test.ts
@@ -1,0 +1,29 @@
+import { isPlaylistReplacement } from '@/composables/playlist'
+import type { Playlist } from '@/types'
+import { describe, expect, it } from 'vitest'
+
+const playlist = (id: string, asset: string): Playlist => ({ id, asset }) as Playlist
+
+describe('isPlaylistReplacement', () => {
+  it('is not a replacement when id and asset are unchanged', () => {
+    const current = playlist('1', 'https://example.test/a?expires=1')
+
+    expect(isPlaylistReplacement(playlist('1', 'https://example.test/a?expires=1'), current)).toBe(false)
+  })
+
+  it('is a replacement when the id changes', () => {
+    const current = playlist('1', 'https://example.test/a?expires=1')
+
+    expect(isPlaylistReplacement(playlist('2', 'https://example.test/a?expires=1'), current)).toBe(true)
+  })
+
+  it('is a replacement when only the asset (a re-signed url) changes', () => {
+    const current = playlist('1', 'https://example.test/a?expires=1')
+
+    expect(isPlaylistReplacement(playlist('1', 'https://example.test/a?expires=2'), current)).toBe(true)
+  })
+
+  it('is not a replacement when there is nothing loaded yet', () => {
+    expect(isPlaylistReplacement(null, null)).toBe(false)
+  })
+})

--- a/resources/js/__tests__/composables/playlist.test.ts
+++ b/resources/js/__tests__/composables/playlist.test.ts
@@ -1,8 +1,9 @@
-import { isPlaylistReplacement } from '@/composables/playlist'
+import { usePlaylist } from '@/composables/playlist'
 import type { Playlist } from '@/types'
 import { describe, expect, it } from 'vitest'
 
 const playlist = (id: string, asset: string): Playlist => ({ id, asset }) as Playlist
+const { isPlaylistReplacement } = usePlaylist()
 
 describe('isPlaylistReplacement', () => {
   it('is not a replacement when id and asset are unchanged', () => {

--- a/resources/js/composables/playlist.ts
+++ b/resources/js/composables/playlist.ts
@@ -1,5 +1,10 @@
 import type { Playlist } from '@/types'
 
-/** Whether `next` is a different playlist row, or the same row re-signed with a new asset url. */
-export const isPlaylistReplacement = (next: Playlist | null, current: Playlist | null): boolean =>
-  next?.id !== current?.id || next?.asset !== current?.asset
+export function usePlaylist() {
+  const isPlaylistReplacement = (next: Playlist | null, current: Playlist | null): boolean =>
+    next?.id !== current?.id || next?.asset !== current?.asset
+
+  return {
+    isPlaylistReplacement,
+  }
+}

--- a/resources/js/composables/playlist.ts
+++ b/resources/js/composables/playlist.ts
@@ -1,0 +1,5 @@
+import type { Playlist } from '@/types'
+
+/** Whether `next` is a different playlist row, or the same row re-signed with a new asset url. */
+export const isPlaylistReplacement = (next: Playlist | null, current: Playlist | null): boolean =>
+  next?.id !== current?.id || next?.asset !== current?.asset

--- a/resources/js/composables/shaka.ts
+++ b/resources/js/composables/shaka.ts
@@ -1,4 +1,4 @@
-import { isPlaylistReplacement } from '@/composables/playlist'
+import { usePlaylist } from '@/composables/playlist'
 import { useSettings } from '@/composables/settings'
 import { useVideo } from '@/composables/video'
 import { configureOverlay, createError, isCriticalError, loadShaka } from '@/plugins/shaka'
@@ -15,7 +15,8 @@ export function useShaka(
   progress?: MaybeRefOrGetter<number | null>,
 ) {
   const { get, update } = useSettings('player')
-  const { markViewed } = useVideo(video)
+  const { isPlaylistReplacement } = usePlaylist()
+  const { markViewed } = useVideo()
 
   const player = shallowRef<shaka.Player>()
   const manager = shallowRef<shaka.util.EventManager>()
@@ -237,7 +238,7 @@ export function useShaka(
         ticker.value = time ?? 0
 
         try {
-          markViewed(time)
+          markViewed(model, time)
         } catch (err) {
           console.error('Error marking video as viewed:', err)
         }

--- a/resources/js/composables/shaka.ts
+++ b/resources/js/composables/shaka.ts
@@ -1,3 +1,4 @@
+import { isPlaylistReplacement } from '@/composables/playlist'
 import { useSettings } from '@/composables/settings'
 import { useVideo } from '@/composables/video'
 import { configureOverlay, getShaka, loadShaka } from '@/plugins/shaka'
@@ -258,7 +259,7 @@ export function useShaka(
       if (loaded.value === false) {
         // Load the initial manifest
         await load(playlistModel, startsAt)
-      } else if (playlistModel.id !== current.value?.id) {
+      } else if (isPlaylistReplacement(playlistModel, current.value)) {
         // Swap in a newly issued manifest (e.g. after the previous one expired) without a full re-initialize
         await replace(playlistModel)
       }

--- a/resources/js/composables/shaka.ts
+++ b/resources/js/composables/shaka.ts
@@ -80,14 +80,12 @@ export function useShaka(
           bufferBehind: 30,
           rebufferingGoal: 0,
           segmentPrefetchLimit: 3,
-          ignoreTextStreamFailures: true,
           retryParameters: {
             baseDelay: 100,
           },
         },
         manifest: {
           dash: { xlinkFailGracefully: true },
-          hls: { ignoreImageStreamFailures: true, ignoreTextStreamFailures: true },
           retryParameters: {
             baseDelay: 100,
           },

--- a/resources/js/composables/shaka.ts
+++ b/resources/js/composables/shaka.ts
@@ -222,7 +222,7 @@ export function useShaka(
     console.error('Shaka Player Error:', detail)
   }
 
-  const onTimeUpdate = useThrottleFn((event: Event) => {
+  const onTimeUpdate = useThrottleFn(async (event: Event) => {
     const model = toValue(video) as Video | null
     const el = event.target as HTMLMediaElement | null
 
@@ -236,7 +236,7 @@ export function useShaka(
         ticker.value = time ?? 0
 
         try {
-          markViewed(model, time)
+          await markViewed(model, time)
         } catch (err) {
           console.error('Error marking video as viewed:', err)
         }

--- a/resources/js/composables/shaka.ts
+++ b/resources/js/composables/shaka.ts
@@ -1,7 +1,7 @@
 import { isPlaylistReplacement } from '@/composables/playlist'
 import { useSettings } from '@/composables/settings'
 import { useVideo } from '@/composables/video'
-import { configureOverlay, getShaka, loadShaka } from '@/plugins/shaka'
+import { configureOverlay, createError, isCriticalError, loadShaka } from '@/plugins/shaka'
 import type { Playlist, Video } from '@/types'
 import { tryOnScopeDispose, useThrottleFn } from '@vueuse/core'
 import type shaka from 'shaka-player/dist/shaka-player.ui'
@@ -122,6 +122,16 @@ export function useShaka(
     ticker.value = startTime ?? null
     error.value = null
 
+    if (playlist.failed) {
+      error.value = createError('MEDIA_SOURCE_OPERATION_FAILED', 'MANIFEST')
+      return
+    }
+
+    if (playlist.expired) {
+      error.value = createError('EXPIRED', 'MANIFEST')
+      return
+    }
+
     // Prepare the configuration for the player, including DRM settings if available
     const config = player.value.getConfiguration()
     const keyId = playlist.encryption_key_id?.toLowerCase() ?? null
@@ -204,13 +214,13 @@ export function useShaka(
   }
 
   const onErrorEvent = (event: Event) => {
-    const shakaError = (event as CustomEvent).detail as shaka.util.Error
+    const detail = (event as CustomEvent).detail as shaka.util.Error | Error
 
-    if (shakaError.severity === getShaka()?.util.Error.Severity.CRITICAL) {
-      error.value = shakaError
+    if (isCriticalError(detail)) {
+      error.value = detail
     }
 
-    console.error('Shaka Player Error:', shakaError)
+    console.error('Shaka Player Error:', detail)
   }
 
   const onTimeUpdate = useThrottleFn((event: Event) => {

--- a/resources/js/composables/video.ts
+++ b/resources/js/composables/video.ts
@@ -12,15 +12,15 @@ export function useVideo() {
     await http.post(VideoSessionController.url({ video: video.id }))
   }
 
-  const toggleLike = async (video: Video) => {
-    await toggleGroup(VideoLikeController.url({ video: video.id }))
+  const toggleLike = (video: Video): void => {
+    toggleGroup(VideoLikeController.url({ video: video.id }))
   }
 
-  const toggleSave = async (video: Video) => {
-    await toggleGroup(VideoSaveController.url({ video: video.id }))
+  const toggleSave = (video: Video): void => {
+    toggleGroup(VideoSaveController.url({ video: video.id }))
   }
 
-  const toggleGroup = async (url: string) =>
+  const toggleGroup = (url: string): void =>
     router.post(
       url,
       {},

--- a/resources/js/composables/video.ts
+++ b/resources/js/composables/video.ts
@@ -3,36 +3,21 @@ import VideoLikeController from '@/actions/App/Web/Videos/Controllers/VideoLikeC
 import VideoSaveController from '@/actions/App/Web/Videos/Controllers/VideoSaveController'
 import type { Video } from '@/types'
 import { router, useHttp } from '@inertiajs/vue3'
-import { computed, toValue, type MaybeRefOrGetter } from 'vue'
 
-export function useVideo(video?: MaybeRefOrGetter<Video | null>) {
+export function useVideo() {
   const http = useHttp({ time: null as number | null })
 
-  const model = computed(() => toValue(video) as Video | null)
-
-  const markViewed = async (time?: number | null): Promise<void> => {
-    const videoId = model.value?.id ?? null
-
-    if (videoId) {
-      http.time = time ?? null
-      http.post(VideoSessionController.url({ video: videoId }))
-    }
+  const markViewed = async (video: Video, time?: number | null): Promise<void> => {
+    http.time = time ?? null
+    await http.post(VideoSessionController.url({ video: video.id }))
   }
 
-  const toggleLike = async () => {
-    const videoId = model.value?.id ?? null
-
-    if (videoId) {
-      toggleGroup(VideoLikeController.url({ video: videoId }))
-    }
+  const toggleLike = async (video: Video) => {
+    await toggleGroup(VideoLikeController.url({ video: video.id }))
   }
 
-  const toggleSave = async () => {
-    const videoId = model.value?.id
-
-    if (videoId) {
-      toggleGroup(VideoSaveController.url({ video: videoId }))
-    }
+  const toggleSave = async (video: Video) => {
+    await toggleGroup(VideoSaveController.url({ video: video.id }))
   }
 
   const toggleGroup = async (url: string) =>

--- a/resources/js/pages/App/Videos/VideoView.vue
+++ b/resources/js/pages/App/Videos/VideoView.vue
@@ -24,7 +24,7 @@ const props = defineProps<{
 
 const isAddModalOpen = ref(false)
 
-const { toggleLike, toggleSave } = useVideo(props.video)
+const { toggleLike, toggleSave } = useVideo()
 const { privateChannel } = useEcho()
 
 const links = computed<ButtonProps[]>(() => [
@@ -36,12 +36,12 @@ const links = computed<ButtonProps[]>(() => [
   {
     label: props.video.liked ? 'Unlike' : 'Like',
     icon: props.video.liked ? 'i-lucide-heart' : 'i-lucide-heart-plus',
-    onClick: () => toggleLike(),
+    onClick: () => toggleLike(props.video),
   },
   {
     label: props.video.saved ? 'Unsave' : 'Save',
     icon: props.video.saved ? 'i-lucide-bookmark' : 'i-lucide-bookmark-plus',
-    onClick: () => toggleSave(),
+    onClick: () => toggleSave(props.video),
   },
   {
     label: 'Add',

--- a/resources/js/plugins/shaka/index.ts
+++ b/resources/js/plugins/shaka/index.ts
@@ -37,6 +37,40 @@ export function getShaka(): typeof shaka | undefined {
   return instance
 }
 
+/**
+ * Builds a shaka.util.Error, defaulting to CRITICAL severity when none is given.
+ * Throws if Shaka Player hasn't been loaded yet, since the error classes only exist on the loaded instance.
+ */
+export function createError(
+  code: keyof typeof shaka.util.Error.Code | null = null,
+  category: keyof typeof shaka.util.Error.Category | null = null,
+  severity: keyof typeof shaka.util.Error.Severity | null = null,
+): shaka.util.Error {
+  if (!instance) {
+    throw new Error('Shaka Player has not been loaded yet.')
+  }
+
+  return new instance.util.Error(
+    instance.util.Error.Severity[severity ?? 'CRITICAL'],
+    (category !== null ? instance.util.Error.Category[category] : null) as shaka.util.Error.Category,
+    (code !== null ? instance.util.Error.Code[code] : null) as shaka.util.Error.Code,
+  )
+}
+
+/**
+ * Determines whether an error should be surfaced to the user.
+ * shaka.util.Error instances are critical only at CRITICAL severity; any other thrown Error is always treated as critical.
+ */
+export function isCriticalError(error: shaka.util.Error | Error): boolean {
+  const ShakaError = instance?.util.Error
+
+  if (ShakaError && error instanceof ShakaError) {
+    return error.severity === ShakaError.Severity.CRITICAL
+  }
+
+  return error instanceof Error
+}
+
 export function configureOverlay(overlay: shaka.ui.Overlay): void {
   overlay.configure({
     doubleClickForFullscreen: false,

--- a/src/Domain/Playlists/Actions/RefreshPlaylistManifest.php
+++ b/src/Domain/Playlists/Actions/RefreshPlaylistManifest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Playlists\Actions;
+
+use Domain\Playlists\Models\Playlist;
+
+class RefreshPlaylistManifest
+{
+    public function handle(Playlist $playlist): void
+    {
+        if (! $playlist->isValid() || $playlist->modelCacheHas('manifest-fresh')) {
+            return;
+        }
+
+        $ttl = max(Playlist::getManifestUrlLifetime() - Playlist::getManifestRefreshBefore(), 0);
+
+        $playlist->modelCache('manifest-fresh', true, now()->addSeconds($ttl));
+
+        // Touching the playlist re-broadcasts it, so viewers pick up a freshly signed manifest URL
+        $playlist->touch();
+    }
+}

--- a/src/Domain/Playlists/Listeners/RefreshExpiringPlaylistManifest.php
+++ b/src/Domain/Playlists/Listeners/RefreshExpiringPlaylistManifest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Playlists\Listeners;
+
+use Domain\Playlists\Actions\RefreshPlaylistManifest;
+use Domain\Videos\Events\VideoHasBeenViewedEvent;
+
+class RefreshExpiringPlaylistManifest
+{
+    public function __construct(protected RefreshPlaylistManifest $refreshPlaylistManifest) {}
+
+    public function handle(VideoHasBeenViewedEvent $event): void
+    {
+        if ($playlist = $event->video->getPlaylist()) {
+            $this->refreshPlaylistManifest->handle($playlist);
+        }
+    }
+}

--- a/src/Domain/Playlists/Models/Playlist.php
+++ b/src/Domain/Playlists/Models/Playlist.php
@@ -14,6 +14,7 @@ use Domain\Playlists\States\PlaylistState;
 use Domain\Playlists\States\Verified;
 use Domain\Shared\Casts\AsDateTime;
 use Domain\Users\Concerns\InteractsWithUser;
+use Foxws\ModelCache\Concerns\InteractsWithModelCache;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\BroadcastsEvents;
@@ -38,6 +39,7 @@ class Playlist extends Model
     use HasFactory;
     use HasStates;
     use HasUlids;
+    use InteractsWithModelCache;
     use InteractsWithUser;
     use Prunable;
 
@@ -286,7 +288,12 @@ class Playlist extends Model
 
     public static function getManifestUrlLifetime(): int
     {
-        return Config::integer('playlists.manifest_url_lifetime', 3600);
+        return Config::integer('playlists.manifest_url_lifetime', 7200);
+    }
+
+    public static function getManifestRefreshBefore(): int
+    {
+        return Config::integer('playlists.manifest_refresh_before', 300);
     }
 
     public static function getManifestCacheLifetime(): int

--- a/src/Domain/Playlists/Models/Playlist.php
+++ b/src/Domain/Playlists/Models/Playlist.php
@@ -288,7 +288,7 @@ class Playlist extends Model
 
     public static function getManifestUrlLifetime(): int
     {
-        return Config::integer('playlists.manifest_url_lifetime', 7200);
+        return Config::integer('playlists.manifest_url_lifetime', 14400);
     }
 
     public static function getManifestRefreshBefore(): int
@@ -303,7 +303,7 @@ class Playlist extends Model
 
     public static function getMediaUrlLifetime(): int
     {
-        return Config::integer('playlists.media_url_lifetime', 7200);
+        return Config::integer('playlists.media_url_lifetime', 14400);
     }
 
     public static function getKeyUrlLifetime(): int

--- a/tests/Feature/Playlist/PlaylistTest.php
+++ b/tests/Feature/Playlist/PlaylistTest.php
@@ -25,7 +25,7 @@ it('can create a playlist with required attributes', function () {
     expect($playlist->exists)->toBeTrue()
         ->and($playlist->user_id)->toBe($user->getKey())
         ->and($playlist->playlistable_id)->toBe($video->getKey())
-        ->and($playlist->playlistable_type)->toBe(Video::class)
+        ->and($playlist->playlistable_type)->toBe($video->getMorphClass())
         ->and($playlist->disk)->toBe('segments')
         ->and($playlist->file_name)->toBe('playlist.m3u8');
 });

--- a/tests/Feature/Playlist/RefreshExpiringPlaylistManifestTest.php
+++ b/tests/Feature/Playlist/RefreshExpiringPlaylistManifestTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Domain\Playlists\Models\Playlist;
+use Domain\Videos\Events\VideoHasBeenViewedEvent;
+use Domain\Videos\Models\Video;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('refreshes the manifest of the video being watched', function () {
+    $video = Video::factory()->create();
+    $playlist = Playlist::factory()->verified()->create([
+        'playlistable_id' => $video->getKey(),
+        'updated_at' => now()->subHour(),
+    ]);
+    $originalUpdatedAt = $playlist->updated_at;
+
+    VideoHasBeenViewedEvent::dispatch($video, null, ['time' => 12.5]);
+
+    expect($playlist->fresh()->updated_at)->not->toEqual($originalUpdatedAt);
+});
+
+it('does nothing when the video has no playlist', function () {
+    $video = Video::factory()->create();
+
+    VideoHasBeenViewedEvent::dispatch($video, null, ['time' => 12.5]);
+
+    expect($video->getPlaylist())->toBeNull();
+});

--- a/tests/Feature/Playlist/RefreshPlaylistManifestTest.php
+++ b/tests/Feature/Playlist/RefreshPlaylistManifestTest.php
@@ -24,6 +24,9 @@ it('does not refresh again while the freshness window is still active', function
     app(RefreshPlaylistManifest::class)->handle($playlist);
     $refreshedAt = $playlist->fresh()->updated_at;
 
+    // Travel forward so a second (unwanted) touch would land on a detectably different timestamp
+    $this->travel(1)->second();
+
     app(RefreshPlaylistManifest::class)->handle($playlist);
 
     expect($playlist->fresh()->updated_at)->toEqual($refreshedAt);

--- a/tests/Feature/Playlist/RefreshPlaylistManifestTest.php
+++ b/tests/Feature/Playlist/RefreshPlaylistManifestTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Domain\Playlists\Actions\RefreshPlaylistManifest;
+use Domain\Playlists\Models\Playlist;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('touches a verified playlist to re-broadcast a freshly signed manifest url', function () {
+    $playlist = Playlist::factory()->verified()->create(['updated_at' => now()->subHour()]);
+    $originalUpdatedAt = $playlist->updated_at;
+
+    app(RefreshPlaylistManifest::class)->handle($playlist);
+
+    expect($playlist->fresh()->updated_at)->not->toEqual($originalUpdatedAt)
+        ->and($playlist->modelCacheHas('manifest-fresh'))->toBeTrue();
+});
+
+it('does not refresh again while the freshness window is still active', function () {
+    $playlist = Playlist::factory()->verified()->create();
+
+    app(RefreshPlaylistManifest::class)->handle($playlist);
+    $refreshedAt = $playlist->fresh()->updated_at;
+
+    app(RefreshPlaylistManifest::class)->handle($playlist);
+
+    expect($playlist->fresh()->updated_at)->toEqual($refreshedAt);
+});
+
+it('refreshes again once the freshness window has elapsed', function () {
+    config()->set('playlists.manifest_url_lifetime', 600);
+    config()->set('playlists.manifest_refresh_before', 300);
+
+    $playlist = Playlist::factory()->verified()->create();
+
+    app(RefreshPlaylistManifest::class)->handle($playlist);
+    $firstRefresh = $playlist->fresh()->updated_at;
+
+    $this->travel(301)->seconds();
+
+    app(RefreshPlaylistManifest::class)->handle($playlist);
+
+    expect($playlist->fresh()->updated_at)->not->toEqual($firstRefresh);
+});
+
+it('does not refresh a playlist that is not verified', function () {
+    $playlist = Playlist::factory()->create();
+    $originalUpdatedAt = $playlist->updated_at;
+
+    app(RefreshPlaylistManifest::class)->handle($playlist);
+
+    expect($playlist->fresh()->updated_at)->toEqual($originalUpdatedAt)
+        ->and($playlist->modelCacheHas('manifest-fresh'))->toBeFalse();
+});

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.app.json",
-  "include": ["resources/**/__tests__/*", "env.d.ts"],
+  "include": ["resources/**/__tests__/**/*", "env.d.ts"],
   "exclude": [],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",


### PR DESCRIPTION
This pull request introduces a manifest refresh mechanism for playlists to ensure uninterrupted playback, refines playlist type handling, and improves error handling in the Shaka player integration. It also adds comprehensive tests for the new behaviors.

**Manifest Refresh and Playlist Handling Improvements:**

* Added a manifest refresh mechanism: When a video is being watched, the system now proactively refreshes and broadcasts a new signed manifest URL before the previous one expires, preventing playback interruptions. This includes new configuration options (`manifest_url_lifetime` and `manifest_refresh_before`), new action and listener classes (`RefreshPlaylistManifest`, `RefreshExpiringPlaylistManifest`), and corresponding tests. [[1]](diffhunk://#diff-078b3ce83f2d18b901067a3f84b1f07d957443d9214322d43a52cae7727fb741L76-R90) [[2]](diffhunk://#diff-ff34da4adbd7201571f8fbe8f5411270c12fd4c010340793655cbd1f706a0688L289-R296) [[3]](diffhunk://#diff-53248f1a17c2dcf812d50cc4af06e993d22b71a4744cec06e5713609744b776eR1-R24) [[4]](diffhunk://#diff-234829036c176022d616204f62a416ff8c33bc22661f83830c646de0e6d01d14R1-R20) [[5]](diffhunk://#diff-200601fdfe7b05c3e0737bf912d8b61bf302c0c4c7ddd754d8cc10933f4cb6bfR1-R31) [[6]](diffhunk://#diff-54dbd81d693e671f32beb0bc7c15d0221cfd705a63c8284f9f6a485aee4a9701R1-R56)
* Updated playlist type handling to use morph class instead of a hardcoded class name, improving polymorphic relationship support. [[1]](diffhunk://#diff-96c85c085e4bdbe85e7defe076fa1c6c6ec96168ad684f30dbca39250b98fd3dL23-R23) [[2]](diffhunk://#diff-d6a045c3bf295601c51af89b5e108a974cdef1f2ad45a7f3ea411805d2b577d1L28-R28)

**Shaka Player Integration Enhancements:**

* Improved error handling in the Shaka integration by introducing utility functions (`createError`, `isCriticalError`) and surfacing manifest expiration and playlist failures as explicit errors in the player. [[1]](diffhunk://#diff-3bc9379cd286b6355e53e5563c06ab771c6e6850a16e0323c525f5df33072404R1-R4) [[2]](diffhunk://#diff-3bc9379cd286b6355e53e5563c06ab771c6e6850a16e0323c525f5df33072404R125-R134) [[3]](diffhunk://#diff-3bc9379cd286b6355e53e5563c06ab771c6e6850a16e0323c525f5df33072404L206-R223) [[4]](diffhunk://#diff-d599b08698bc28003d90556a87d4f45913b5cad15328beff3ffce038029658eaR40-R73)
* Added a utility function (`isPlaylistReplacement`) and corresponding tests to determine when a playlist should be replaced in the player, ensuring seamless manifest URL updates. [[1]](diffhunk://#diff-ff28723a98e7b084868f773d0fbdcf4a2638d2f942ff6cb2d32268f2b20576f3R1-R5) [[2]](diffhunk://#diff-0e3afb907b0c9909626886795662283edd74925d2b2988e539de9273e821c8edR1-R29) [[3]](diffhunk://#diff-3bc9379cd286b6355e53e5563c06ab771c6e6850a16e0323c525f5df33072404L261-R272)

**Testing and Configuration:**

* Added and expanded tests for playlist manifest refresh logic and playlist replacement detection. [[1]](diffhunk://#diff-200601fdfe7b05c3e0737bf912d8b61bf302c0c4c7ddd754d8cc10933f4cb6bfR1-R31) [[2]](diffhunk://#diff-54dbd81d693e671f32beb0bc7c15d0221cfd705a63c8284f9f6a485aee4a9701R1-R56) [[3]](diffhunk://#diff-0e3afb907b0c9909626886795662283edd74925d2b2988e539de9273e821c8edR1-R29)
* Updated TypeScript test configuration to include nested test files.…ests